### PR TITLE
Cross compiled binary builds for linux and windows

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goos: [linux]
-        goarch: [amd64]
+        goos: [linux, darwin, windows]
+        goarch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Go
@@ -24,13 +24,13 @@ jobs:
       - name: Run tests
         run: go test -v ./tests
   releases-matrix:
-    name: Release Go Binary
+    name: Cross compile and release Go Binaries
     runs-on: ubuntu-latest
     needs: tests-matrix
     strategy:
-      matrix:
-        goos: [linux]
-        goarch: [amd64]
+        # Release of unsigned darwin binaries
+        goos: [linux, darwin, windows]
+        goarch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v2
       - name: Set output
@@ -43,6 +43,6 @@ jobs:
           goarch: ${{ matrix.goarch }}
           release_tag: master
           overwrite: true
-          goversion: "https://go.dev/dl/go1.17.6.${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz"
+          goversion: "https://go.dev/dl/go1.17.6.linux-amd64.tar.gz"
           binary_name: "silta"
           ldflags: "-X github.com/wunderio/silta-cli/internal/common.Version=${{ steps.vars.outputs.sha_short }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goos: [linux]
-        goarch: [amd64]
+        goos: [linux, darwin, windows]
+        goarch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Go
@@ -24,13 +24,13 @@ jobs:
       - name: Run tests
         run: go test -v ./tests
   releases-matrix:
-    name: Release Go Binary
+    name: Cross compile and release Go Binaries
     runs-on: ubuntu-latest
     needs: tests-matrix
     strategy:
       matrix:
-        goos: [linux]
-        goarch: [amd64]
+        goos: [linux, windows]
+        goarch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v2
       - name: Set output
@@ -41,6 +41,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
-          goversion: "https://go.dev/dl/go1.17.6.${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz"
+          goversion: "https://go.dev/dl/go1.17.6.linux-amd64.tar.gz"
           binary_name: "silta"
           ldflags: "-X github.com/wunderio/silta-cli/internal/common.Version=${{ steps.vars.outputs.tag }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goos: [linux]
-        goarch: [amd64]
+        goos: [linux, darwin, windows]
+        goarch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Go
@@ -24,13 +24,14 @@ jobs:
       - name: Run tests
         run: go test -v ./tests
   releases-matrix:
-    name: Release Go Binary
+    name: Cross compile and release Go Binaries
     runs-on: ubuntu-latest
     needs: tests-matrix
     strategy:
       matrix:
-        goos: [linux]
-        goarch: [amd64]
+        # Release of unsigned darwin binaries
+        goos: [linux, darwin, windows]
+        goarch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v2
       - name: Set output
@@ -43,6 +44,6 @@ jobs:
           goarch: ${{ matrix.goarch }}
           release_tag: test
           overwrite: true
-          goversion: "https://go.dev/dl/go1.17.6.${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz"
+          goversion: "https://go.dev/dl/go1.17.6.linux-amd64.tar.gz"
           binary_name: "silta"
           ldflags: "-X github.com/wunderio/silta-cli/internal/common.Version=${{ steps.vars.outputs.sha_short }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,48 @@
+name: Build silta cli binary and attach to test release
+
+on:
+  push:
+    branches: [ feature/* ]
+  
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  tests-matrix:
+    name: Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux]
+        goarch: [amd64]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.6
+      - name: Run tests
+        run: go test -v ./tests
+  releases-matrix:
+    name: Release Go Binary
+    runs-on: ubuntu-latest
+    needs: tests-matrix
+    strategy:
+      matrix:
+        goos: [linux]
+        goarch: [amd64]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set output
+        id: vars
+        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+      - uses: wangyoucao577/go-release-action@v1.24
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          goos: ${{ matrix.goos }}
+          goarch: ${{ matrix.goarch }}
+          release_tag: test
+          overwrite: true
+          goversion: "https://go.dev/dl/go1.17.6.${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz"
+          binary_name: "silta"
+          ldflags: "-X github.com/wunderio/silta-cli/internal/common.Version=${{ steps.vars.outputs.sha_short }}"


### PR DESCRIPTION
- Attaches feature branch test binaries to "test" release
- Builds and attaches windows and os/x (darwin) binaries to master and test releases. Darwin binaries are unsigned at the moment, can't be run without extra signing process
- Builds and attaches windows binaries to standard releases
- Builds arm64 arch binaries