### PR TITLE
Normalize separators for encoded file list

### DIFF
--- a/IDEAS.txt
+++ b/IDEAS.txt
@@ -1,0 +1,8 @@
+# Gox - Simple Go Cross Compilation
+https://github.com/mitchellh/gox
+
+# Binary signing for OS/X
+https://www.kencochrane.com/2020/08/01/build-and-sign-golang-binaries-for-macos-with-github-actions/
+
+# Self updating
+https://github.com/rhysd/go-github-selfupdate

--- a/cmd/secretsDecrypt.go
+++ b/cmd/secretsDecrypt.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"regexp"
 	"strings"
 
 	"encoding/base64"
@@ -31,19 +32,29 @@ var secretsDecryptCmd = &cobra.Command{
 			}
 		}
 
+		// Replace comma with whitespace and iterate all whitespace separated values.
+		// This also means there can't be commas nor whitespaces in filenames.
+		space := regexp.MustCompile(`,\s?|\s+`)
+		files = space.ReplaceAllString(files, " ")
+
 		// Allow failing with exit code 0 when no files defined.
 		if len(files) == 0 {
 			fmt.Println("No input files supplied")
 			return
 		}
 
-		// Split on comma.
-		fileList := strings.Split(files, ",")
+		// Split on whitespace.
+		fileList := strings.Split(files, " ")
 
 		// Decrypt files
 		for i := range fileList {
 			file := fileList[i]
 			fmt.Printf("Decrypting %s\n", file)
+
+			if debug == true {
+				fmt.Print("..skipping\n")
+				continue
+			}
 
 			// Read encrypted file
 			encryptedMsg, err := os.ReadFile(file)

--- a/tests/secrets_test.go
+++ b/tests/secrets_test.go
@@ -80,6 +80,20 @@ func TestSecretsEncryptDecryptCmd(t *testing.T) {
 		t.Error("Decrypted file incorrect")
 	}
 
+	// Test multiple file separator
+	command = "secrets decrypt --file 'tests/test-secret1,tests/test-secret2, tests/test-secret3 tests/test-secret4' --secret-key test --debug"
+	environment = []string{}
+	testString = `Decrypting tests/test-secret1
+..skipping
+Decrypting tests/test-secret2
+..skipping
+Decrypting tests/test-secret3
+..skipping
+Decrypting tests/test-secret4
+..skipping
+`
+	CliExecTest(t, command, environment, testString, true)
+
 	// Change dir back to previous
 	os.Chdir(wd)
 }


### PR DESCRIPTION
Replicates https://github.com/wunderio/silta-circleci/pull/152

Allows mixed encrypted file list separators, i.e. `secrets decrypt --file 'secret1 secret2,secret3, secret4'`

