### PR TITLE
Feature/validation refactor

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -17,6 +17,12 @@ jobs:
         goarch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v2
+      - uses: azure/setup-helm@v3
+        with:
+          version: 'v3.9.0'
+        name: Install Helm
+      - name: Add wunderio Helm repo
+        run: helm repo add wunderio https://storage.googleapis.com/charts.wdr.io
       - name: Set up Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: azure/setup-helm@v3
         with:
-          version: 'v3.9.0'
+          version: 'v3.6.3'
         name: Install Helm
       - name: Add wunderio Helm repo
         run: helm repo add wunderio https://storage.googleapis.com/charts.wdr.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,12 @@ jobs:
         goarch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v2
+      - uses: azure/setup-helm@v3
+        with:
+          version: 'v3.9.0'
+        name: Install Helm
+      - name: Add wunderio Helm repo
+        run: helm repo add wunderio https://storage.googleapis.com/charts.wdr.io
       - name: Set up Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: azure/setup-helm@v3
         with:
-          version: 'v3.9.0'
+          version: 'v3.6.3'
         name: Install Helm
       - name: Add wunderio Helm repo
         run: helm repo add wunderio https://storage.googleapis.com/charts.wdr.io

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           version: 'v3.9.0'
         name: Install Helm
+      - name: Add wunderio Helm repo
+        run: helm repo add wunderio https://storage.googleapis.com/charts.wdr.io
       - name: Set up Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: azure/setup-helm@v3
         with:
-          version: 'v3.9.0'
+          version: 'v3.6.3'
         name: Install Helm
       - name: Add wunderio Helm repo
         run: helm repo add wunderio https://storage.googleapis.com/charts.wdr.io

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,10 @@ jobs:
         goarch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v2
+      - uses: azure/setup-helm@v3
+        with:
+          version: 'v3.9.0'
+        name: Install Helm
       - name: Set up Go
         uses: actions/setup-go@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,6 @@ build:
 	go mod download
 	go build -a -gcflags=-trimpath=$(go env GOPATH) -asmflags=-trimpath=$(go env GOPATH) -ldflags "-X github.com/wunderio/silta-cli/internal/common.Version=$(VERSION)" -o silta
 
-build_move:
-	make build
-	cp silta bintest/
-
 test:
 	go test ./tests
 

--- a/cmd/ciChartExtend.go
+++ b/cmd/ciChartExtend.go
@@ -53,11 +53,13 @@ var editChartCmd = &cobra.Command{
 			var d = common.ReadChartDefinition(p[1] + innerChartFile)
 			common.AppendExtraCharts(&l, &d)
 			common.WriteChartDefinition(d, p[1]+innerChartFile)
+			common.AppendToChartSchemaFile(chartName+"/values.schema.json", chartName)
 		} else {
 			var l = common.ReadCharts(deploymentFlag)
 			var d = common.ReadChartDefinition(chartName + innerChartFile)
 			common.AppendExtraCharts(&l, &d)
 			common.WriteChartDefinition(d, chartName+innerChartFile)
+			common.AppendToChartSchemaFile(chartName+"/values.schema.json", chartName)
 		}
 
 	},

--- a/cmd/ciChartExtend.go
+++ b/cmd/ciChartExtend.go
@@ -70,11 +70,11 @@ var editChartCmd = &cobra.Command{
 				log.Print("Chart doesnt exist locally")
 			}
 			common.DownloadUntarChart(&c, true)
-			var l = common.ReadCharts(deploymentFlag)
-			var d = common.ReadChartDefinition(common.ExtendedFolder + "/" + p[1] + innerChartFile)
-			common.AppendExtraCharts(&l, &d)
-			common.WriteChartDefinition(d, common.ExtendedFolder+"/"+p[1]+innerChartFile)
-			common.AppendToChartSchemaFile(common.ExtendedFolder+"/"+p[1]+"/values.schema.json", common.GetChartNamesFromDependencies(l.Charts))
+			var chartsToAdd = common.ReadCharts(deploymentFlag)
+			var mainChartDefinition = common.ReadChartDefinition(common.ExtendedFolder + "/" + p[1] + innerChartFile)
+			common.AppendExtraCharts(&chartsToAdd, &mainChartDefinition)
+			common.WriteChartDefinition(mainChartDefinition, common.ExtendedFolder+"/"+p[1]+innerChartFile)
+			common.AppendToChartSchemaFile(common.ExtendedFolder+"/"+p[1]+"/values.schema.json", common.GetChartNamesFromDependencies(chartsToAdd.Charts))
 			helmCmdString := "helm dep update " + common.ExtendedFolder + "/" + p[1]
 			helmCmd, helmErr = exec.Command("bash", "-c", helmCmdString).CombinedOutput()
 		} else {

--- a/cmd/ciChartExtend.go
+++ b/cmd/ciChartExtend.go
@@ -47,8 +47,7 @@ var editChartCmd = &cobra.Command{
 			c.Version = ""
 		}
 
-		p := strings.SplitN(chartUrl.Path, "/", 2)
-
+		p := strings.Split(chartUrl.Path, "/")
 		if debug == true {
 			log.Println("p[0] ", p[0])
 			log.Println("p[1] ", p[1])
@@ -83,6 +82,10 @@ var editChartCmd = &cobra.Command{
 		} else {
 
 			if chartExistsLocally {
+				if debug == true {
+					log.Println("chartName ", chartName)
+					log.Println("common.ExtendedFolder+ / p[len(p)-1] ", common.ExtendedFolder+"/"+p[len(p)-1])
+				}
 				err := os.Rename(chartName, common.ExtendedFolder+"/"+p[len(p)-1])
 				if err != nil {
 					log.Println("Cant move chart directory")

--- a/cmd/ciChartExtend.go
+++ b/cmd/ciChartExtend.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/url"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -55,6 +56,8 @@ var editChartCmd = &cobra.Command{
 			log.Println("c.Name ", c.Name)
 		}
 
+		var helmErr error
+		var helmCmd []byte
 		_, errDir = os.Stat(common.ExtendedFolder)
 		if os.IsNotExist(errDir) {
 			os.Mkdir(common.ExtendedFolder, 0744)
@@ -75,6 +78,8 @@ var editChartCmd = &cobra.Command{
 			for _, v := range l.Charts {
 				common.AppendToChartSchemaFile(common.ExtendedFolder+"/"+p[1]+"/values.schema.json", v.Name)
 			}
+			helmCmdString := "helm dep update " + common.ExtendedFolder + "/" + p[1]
+			helmCmd, helmErr = exec.Command("bash", "-c", helmCmdString).CombinedOutput()
 		} else {
 
 			if chartExistsLocally {
@@ -90,6 +95,13 @@ var editChartCmd = &cobra.Command{
 			for _, v := range l.Charts {
 				common.AppendToChartSchemaFile(common.ExtendedFolder+"/"+p[len(p)-1]+"/values.schema.json", v.Name)
 			}
+			helmCmdString := "helm dep update " + common.ExtendedFolder + "/" + p[len(p)-1]
+			helmCmd, helmErr = exec.Command("bash", "-c", helmCmdString).CombinedOutput()
+		}
+
+		if helmErr != nil {
+			log.SetFlags(0) //remove timestamp
+			log.Fatal(string(helmCmd[:]))
 		}
 
 	},

--- a/cmd/ciChartExtend.go
+++ b/cmd/ciChartExtend.go
@@ -74,9 +74,7 @@ var editChartCmd = &cobra.Command{
 			var d = common.ReadChartDefinition(common.ExtendedFolder + "/" + p[1] + innerChartFile)
 			common.AppendExtraCharts(&l, &d)
 			common.WriteChartDefinition(d, common.ExtendedFolder+"/"+p[1]+innerChartFile)
-			for _, v := range l.Charts {
-				common.AppendToChartSchemaFile(common.ExtendedFolder+"/"+p[1]+"/values.schema.json", v.Name)
-			}
+			common.AppendToChartSchemaFile(common.ExtendedFolder+"/"+p[1]+"/values.schema.json", common.GetChartNamesFromDependencies(l.Charts))
 			helmCmdString := "helm dep update " + common.ExtendedFolder + "/" + p[1]
 			helmCmd, helmErr = exec.Command("bash", "-c", helmCmdString).CombinedOutput()
 		} else {
@@ -92,12 +90,10 @@ var editChartCmd = &cobra.Command{
 				}
 			}
 			var l = common.ReadCharts(deploymentFlag)
-			var d = common.ReadChartDefinition(common.ExtendedFolder + "/" + p[len(p)-1] + innerChartFile)
+			var d = common.ReadChartDefinition(common.ExtendedFolder + "/" + p[len(p)-1] + innerChartFile) //source chart
 			common.AppendExtraCharts(&l, &d)
 			common.WriteChartDefinition(d, common.ExtendedFolder+"/"+p[len(p)-1]+innerChartFile)
-			for _, v := range l.Charts {
-				common.AppendToChartSchemaFile(common.ExtendedFolder+"/"+p[len(p)-1]+"/values.schema.json", v.Name)
-			}
+			common.AppendToChartSchemaFile(common.ExtendedFolder+"/"+p[len(p)-1]+"/values.schema.json", common.GetChartNamesFromDependencies(l.Charts))
 			helmCmdString := "helm dep update " + common.ExtendedFolder + "/" + p[len(p)-1]
 			helmCmd, helmErr = exec.Command("bash", "-c", helmCmdString).CombinedOutput()
 		}

--- a/cmd/ciReleaseDeploy.go
+++ b/cmd/ciReleaseDeploy.go
@@ -158,6 +158,11 @@ var ciReleaseDeployCmd = &cobra.Command{
 				log.Fatal("Nginx image url required (nginx-image-url)")
 			}
 
+			_, errDir := os.Stat(common.ExtendedFolder + "/simple")
+			if os.IsNotExist(errDir) == false {
+				chartName = common.ExtendedFolder + "/simple"
+			}
+
 			fmt.Printf("Deploying %s helm release %s in %s namespace\n", chartName, releaseName, namespace)
 
 			// helm release
@@ -203,6 +208,11 @@ var ciReleaseDeployCmd = &cobra.Command{
 		} else if chartName == "frontend" || strings.HasSuffix(chartName, "/frontend") {
 
 			fmt.Printf("Deploying %s helm release %s in %s namespace\n", chartName, releaseName, namespace)
+
+			_, errDir := os.Stat(common.ExtendedFolder + "/frontend")
+			if os.IsNotExist(errDir) == false {
+				chartName = common.ExtendedFolder + "/frontend"
+			}
 
 			// helm release
 			command = fmt.Sprintf(`
@@ -328,6 +338,11 @@ var ciReleaseDeployCmd = &cobra.Command{
 			}
 			if len(shellImageUrl) == 0 {
 				log.Fatal("Shell image url required (shell-image-url)")
+			}
+
+			_, errDir := os.Stat(common.ExtendedFolder + "/drupal")
+			if os.IsNotExist(errDir) == false {
+				chartName = common.ExtendedFolder + "/drupal"
 			}
 
 			// Special updates

--- a/cmd/ciReleaseValidate.go
+++ b/cmd/ciReleaseValidate.go
@@ -81,6 +81,11 @@ var ciReleaseValidateCmd = &cobra.Command{
 
 		if chartName == "drupal" || strings.HasSuffix(chartName, "/drupal") {
 
+			_, errDir := os.Stat(common.ExtendedFolder + "/drupal")
+			if os.IsNotExist(errDir) == false {
+				chartName = common.ExtendedFolder + "/drupal"
+			}
+
 			fmt.Printf("Deploying %s helm release %s in %s namespace\n", chartName, releaseName, namespace)
 
 			// TODO: rewrite the timeout handling and log printing after helm release

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/Luzifer/go-openssl/v4 v4.1.0
 	github.com/spf13/cobra v1.3.0
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -13,5 +14,4 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/tests/assets/extension_test/deployment_options.yml
+++ b/tests/assets/extension_test/deployment_options.yml
@@ -1,0 +1,5 @@
+charts:
+- name: redis
+  version: 16.8.x
+  repository: https://charts.bitnami.com/bitnami
+  condition: redis.enabled

--- a/tests/cmd_test.go
+++ b/tests/cmd_test.go
@@ -2,7 +2,6 @@ package cmd_test
 
 import (
 	"bytes"
-	"log"
 	"os"
 	"os/exec"
 	"strings"
@@ -33,49 +32,6 @@ func CliExecTest(t *testing.T, command string, environment []string, testString 
 	cmd.Stderr = &err
 	cmd.Stdout = &out
 	cmd.Run()
-
-	if equals == true {
-		if out.String() == testString || err.String() == testString {
-		} else {
-			t.Logf("Error: %s", err.String())
-			t.Errorf("Expected :\n '%s' \n Received: \n '%s'\n'%s'", testString, out.String(), err.String())
-		}
-
-	} else {
-		if strings.Contains(out.String(), testString) || strings.Contains(err.String(), testString) {
-		} else {
-			t.Logf("Error: %s", err.String())
-			t.Errorf("Expected :\n '%s' \n Received: \n '%s'\n'%s'", testString, out.String(), err.String())
-		}
-	}
-}
-
-func CliExecTest1(t *testing.T, command string, environment []string, testString string, equals bool) {
-
-	// TMP: Do not build
-	// cliBinaryName = "go run main.go"
-	// environment = os.Environ()
-
-	// fmt.Printf("%s", command)
-
-	cmd := exec.Command("bash", "-c", cliBinaryName+" "+command)
-
-	// PATH is missing from exec env, we'll merge in existing os.Environ() as a base
-	mergedEnv := os.Environ()
-	for index, _ := range environment {
-		mergedEnv = append(mergedEnv, environment[index])
-	}
-
-	cmd.Env = mergedEnv
-
-	var out, err bytes.Buffer
-	cmd.Stderr = &err
-	cmd.Stdout = &out
-
-	cmd.Run()
-
-	log.Println("ERR: " + err.String())
-	log.Println("OUT: " + out.String())
 
 	if equals == true {
 		if out.String() == testString || err.String() == testString {

--- a/tests/cmd_test.go
+++ b/tests/cmd_test.go
@@ -2,6 +2,7 @@ package cmd_test
 
 import (
 	"bytes"
+	"log"
 	"os"
 	"os/exec"
 	"strings"
@@ -32,6 +33,49 @@ func CliExecTest(t *testing.T, command string, environment []string, testString 
 	cmd.Stderr = &err
 	cmd.Stdout = &out
 	cmd.Run()
+
+	if equals == true {
+		if out.String() == testString || err.String() == testString {
+		} else {
+			t.Logf("Error: %s", err.String())
+			t.Errorf("Expected :\n '%s' \n Received: \n '%s'\n'%s'", testString, out.String(), err.String())
+		}
+
+	} else {
+		if strings.Contains(out.String(), testString) || strings.Contains(err.String(), testString) {
+		} else {
+			t.Logf("Error: %s", err.String())
+			t.Errorf("Expected :\n '%s' \n Received: \n '%s'\n'%s'", testString, out.String(), err.String())
+		}
+	}
+}
+
+func CliExecTest1(t *testing.T, command string, environment []string, testString string, equals bool) {
+
+	// TMP: Do not build
+	// cliBinaryName = "go run main.go"
+	// environment = os.Environ()
+
+	// fmt.Printf("%s", command)
+
+	cmd := exec.Command("bash", "-c", cliBinaryName+" "+command)
+
+	// PATH is missing from exec env, we'll merge in existing os.Environ() as a base
+	mergedEnv := os.Environ()
+	for index, _ := range environment {
+		mergedEnv = append(mergedEnv, environment[index])
+	}
+
+	cmd.Env = mergedEnv
+
+	var out, err bytes.Buffer
+	cmd.Stderr = &err
+	cmd.Stdout = &out
+
+	cmd.Run()
+
+	log.Println("ERR: " + err.String())
+	log.Println("OUT: " + out.String())
 
 	if equals == true {
 		if out.String() == testString || err.String() == testString {

--- a/tests/extension_test.go
+++ b/tests/extension_test.go
@@ -14,7 +14,7 @@ import (
 func TestChartExtensionCmd(t *testing.T) {
 
 	var originalCli = cliBinaryName
-	cliBinaryName = "../../../../silta"
+	cliBinaryName = "../../../silta"
 
 	// Go to main directory
 	wd, _ := os.Getwd()
@@ -28,8 +28,10 @@ func TestChartExtensionCmd(t *testing.T) {
 	log.Print(os.Getwd())
 	helmCmd, _ := exec.Command("bash", "-c", "ls").CombinedOutput()
 	log.Println(string(helmCmd))
-	schema, err := ioutil.ReadFile(common.ExtendedFolder + "/frontend/values.schema.json")
-	chart, err1 := ioutil.ReadFile(common.ExtendedFolder + "/frontend/Chart.yaml")
+	helmCmd1, _ := exec.Command("bash", "-c", "ls extended-helm-chart").CombinedOutput()
+	log.Println(string(helmCmd1))
+	schema, err := ioutil.ReadFile("./" + common.ExtendedFolder + "/frontend/values.schema.json")
+	chart, err1 := ioutil.ReadFile("./" + common.ExtendedFolder + "/frontend/Chart.yaml")
 
 	cliBinaryName = originalCli
 

--- a/tests/extension_test.go
+++ b/tests/extension_test.go
@@ -14,7 +14,7 @@ import (
 func TestChartExtensionCmd(t *testing.T) {
 
 	var originalCli = cliBinaryName
-	cliBinaryName = "../../../silta"
+	cliBinaryName = "../../../../silta"
 
 	// Go to main directory
 	wd, _ := os.Getwd()

--- a/tests/extension_test.go
+++ b/tests/extension_test.go
@@ -23,7 +23,7 @@ func TestChartExtensionCmd(t *testing.T) {
 	command := "chart extend --chart-name wunderio/frontend --subchart-list-file deployment_options.yml"
 	environment := []string{}
 	testString := ""
-	CliExecTest(t, command, environment, testString, false)
+	CliExecTest1(t, command, environment, testString, false)
 
 	log.Print(os.Getwd())
 	helmCmd, _ := exec.Command("bash", "-c", "ls").CombinedOutput()

--- a/tests/extension_test.go
+++ b/tests/extension_test.go
@@ -1,0 +1,57 @@
+package cmd_test
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/wunderio/silta-cli/internal/common"
+)
+
+func TestChartExtensionCmd(t *testing.T) {
+
+	var originalCli = cliBinaryName
+	cliBinaryName = "../../../silta"
+
+	// Go to main directory
+	wd, _ := os.Getwd()
+
+	os.Chdir("assets/extension_test")
+	command := "chart extend --chart-name wunderio/frontend --subchart-list-file deployment_options.yml"
+	environment := []string{}
+	testString := ""
+	CliExecTest(t, command, environment, testString, false)
+
+	schema, err := ioutil.ReadFile(common.ExtendedFolder + "/frontend/values.schema.json")
+	chart, err1 := ioutil.ReadFile(common.ExtendedFolder + "/frontend/Chart.yaml")
+
+	if err != nil {
+		log.Println(err)
+		t.FailNow()
+	}
+	if err1 != nil {
+		log.Println(err1)
+		t.FailNow()
+	}
+
+	schemaStr := string(schema)
+	chartStr := string(chart)
+	if strings.Contains(schemaStr, "redis") == false {
+		log.Println("Redis not present in values.schema.json")
+		t.Fail()
+	}
+	if strings.Contains(chartStr, "redis") == false {
+		log.Println("Redis not present in Chart.yaml")
+		t.Fail()
+	}
+
+	// Cleanup
+	cliBinaryName = originalCli
+	os.RemoveAll(common.ExtendedFolder)
+
+	// Change dir back to previous
+	os.Chdir(wd)
+
+}

--- a/tests/extension_test.go
+++ b/tests/extension_test.go
@@ -31,20 +31,20 @@ func TestChartExtensionCmd(t *testing.T) {
 
 	if err != nil {
 		log.Println(err)
-		t.FailNow()
+		t.Fail()
 	}
 	if err1 != nil {
 		log.Println(err1)
-		t.FailNow()
+		t.Fail()
 	}
 
 	schemaStr := string(schema)
 	chartStr := string(chart)
-	if strings.Contains(schemaStr, "redis") == false {
+	if strings.Contains(schemaStr, "redis") == false && err == nil {
 		log.Println("Redis not present in values.schema.json")
 		t.Fail()
 	}
-	if strings.Contains(chartStr, "redis") == false {
+	if strings.Contains(chartStr, "redis") == false && err1 == nil {
 		log.Println("Redis not present in Chart.yaml")
 		t.Fail()
 	}

--- a/tests/extension_test.go
+++ b/tests/extension_test.go
@@ -23,7 +23,7 @@ func TestChartExtensionCmd(t *testing.T) {
 	command := "chart extend --chart-name wunderio/frontend --subchart-list-file deployment_options.yml"
 	environment := []string{}
 	testString := ""
-	CliExecTest1(t, command, environment, testString, false)
+	CliExecTest(t, command, environment, testString, false)
 
 	log.Print(os.Getwd())
 	helmCmd, _ := exec.Command("bash", "-c", "ls").CombinedOutput()

--- a/tests/extension_test.go
+++ b/tests/extension_test.go
@@ -27,6 +27,8 @@ func TestChartExtensionCmd(t *testing.T) {
 	schema, err := ioutil.ReadFile(common.ExtendedFolder + "/frontend/values.schema.json")
 	chart, err1 := ioutil.ReadFile(common.ExtendedFolder + "/frontend/Chart.yaml")
 
+	cliBinaryName = originalCli
+
 	if err != nil {
 		log.Println(err)
 		t.FailNow()
@@ -48,7 +50,6 @@ func TestChartExtensionCmd(t *testing.T) {
 	}
 
 	// Cleanup
-	cliBinaryName = originalCli
 	os.RemoveAll(common.ExtendedFolder)
 
 	// Change dir back to previous

--- a/tests/extension_test.go
+++ b/tests/extension_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -24,6 +25,9 @@ func TestChartExtensionCmd(t *testing.T) {
 	testString := ""
 	CliExecTest(t, command, environment, testString, false)
 
+	log.Print(os.Getwd())
+	helmCmd, _ := exec.Command("bash", "-c", "ls").CombinedOutput()
+	log.Println(string(helmCmd))
 	schema, err := ioutil.ReadFile(common.ExtendedFolder + "/frontend/values.schema.json")
 	chart, err1 := ioutil.ReadFile(common.ExtendedFolder + "/frontend/Chart.yaml")
 


### PR DESCRIPTION
Extends chart with additional subcharts.

Testing:
1. Have a file with charts to add - [deployment file](https://github.com/wunderio/silta-cli/blob/8162ce1f4bd6b1475787ac30dee5683a28728ed8/tests/assets/extension_test/deployment_options.yml)
2. Execute `silta chart extend --chart-name wunderio/frontend --subchart-list-file deployment_options.yml`
3. In the newly created `extended-helm-chart/frontend` chart, check if redis is referenced in Chart.yaml and values.schema.json
4. When installing `frontend` chart locally, `extended-helm chart` should take precedence and use that version
