### PR TITLE
Release name length fix

### DIFF
--- a/cmd/ciReleaseName.go
+++ b/cmd/ciReleaseName.go
@@ -37,8 +37,7 @@ var ciReleaseNameCmd = &cobra.Command{
 		releaseName := reg.ReplaceAllString(branchnameLower, "-")
 
 		suffix := ""
-		// TODO: Yes, this part of logic is a bit broken in orb. Keeping it in sync for now, will fix later.
-		if len(releaseSuffix) > 0 && len(releaseSuffix+releaseName) > 39 {
+		if len(releaseSuffix+releaseName) > 39 {
 			suffix = releaseSuffix
 
 			if len(suffix) > 12 {

--- a/internal/common/ciReleaseEnvironmentname.go
+++ b/internal/common/ciReleaseEnvironmentname.go
@@ -11,8 +11,7 @@ func SiltaEnvironmentName(branchname string, releaseSuffix string) string {
 	siltaEnvironmentName := strings.ToLower(branchname)
 
 	suffix := ""
-	// TODO: Yes, this part of logic is a bit broken in orb. Keeping it in sync for now, will fix later (see "ci release name" cmd)
-	if len(releaseSuffix) > 0 && len(releaseSuffix+siltaEnvironmentName) > 39 {
+	if len(releaseSuffix+siltaEnvironmentName) > 39 {
 		suffix = releaseSuffix
 
 		if len(suffix) > 12 {

--- a/tests/release-name.sh
+++ b/tests/release-name.sh
@@ -27,9 +27,10 @@ release_name="${branchname_lower//[^[:alnum:]]/-}"
 suffix_test="${RELEASE_SUFFIX}"
 declare -i total_length=${#suffix_test}+${#release_name}
 suffix=''
-if [[ -n "${RELEASE_SUFFIX}" && $total_length -gt 39 ]]; then
+# if [[ -n "${RELEASE_SUFFIX}" && $total_length -gt 39 ]]; then
+if [[ $total_length -gt 39 ]]; then
   suffix="${RELEASE_SUFFIX}"
-  if [ ${#suffix} -gt 12 ]; then
+  if [[ -n "${RELEASE_SUFFIX}" && ${#suffix} -gt 12 ]]; then
     suffix="$(printf "$suffix" | cut -c 1-7)-$(printf "$suffix" | shasum -a 256 | cut -c 1-4 )"
   fi
   #Maximum length of a release name + release suffix. -1 is for separating '-' char before suffix

--- a/tests/release_test.go
+++ b/tests/release_test.go
@@ -35,16 +35,22 @@ func TestReleaseNameCmd(t *testing.T) {
 	testString = `111111111122222222223333333333444444444`
 	CliExecTest(t, command, environment, testString, true)
 
-	// 40 char long release name test
+	// 40 char long release name test.
 	command = "ci release name --branchname 1111111111222222222233333333334444444444 --debug"
 	environment = []string{}
-	testString = `1111111111222222222233333333334444444444`
+	testString = `1111111111222222222233333333334444-808c`
 	CliExecTest(t, command, environment, testString, true)
 
 	// 41 char long release name test
 	command = "ci release name --branchname 11111111112222222222333333333344444444445 --release-suffix 123456789012345 --debug"
 	environment = []string{}
 	testString = `1111111111222222222233-d0c4-1234567-e27a`
+	CliExecTest(t, command, environment, testString, true)
+
+	// 50 char long release name test
+	command = "ci release environmentname --branchname 11111111112222222222333333333344444444445555555555 --debug"
+	environment = []string{}
+	testString = `1111111111222222222233333333334444-81f3`
 	CliExecTest(t, command, environment, testString, true)
 
 	// 41 char release name + 15 char suffix test
@@ -90,7 +96,13 @@ func TestReleaseEnvironmentnameCmd(t *testing.T) {
 	// 40 char long release name test
 	command = "ci release environmentname --branchname 1111111111222222222233333333334444444444 --debug"
 	environment = []string{}
-	testString = `1111111111222222222233333333334444444444`
+	testString = `1111111111222222222233333333334444-808c`
+	CliExecTest(t, command, environment, testString, true)
+
+	// 50 char long release name test
+	command = "ci release environmentname --branchname 11111111112222222222333333333344444444445555555555 --debug"
+	environment = []string{}
+	testString = `1111111111222222222233333333334444-81f3`
 	CliExecTest(t, command, environment, testString, true)
 
 	// 41 char long release name test


### PR DESCRIPTION
Existing release name trimming is broken and allows unlimited release name length (helm will return error, but it's still inconsistent).