### PR TITLE
Print event and logs for failing pods during deployment

### DIFF
--- a/tests/release_test.go
+++ b/tests/release_test.go
@@ -158,16 +158,35 @@ func TestReleaseDeployCmd(t *testing.T) {
 
 			# Detect pods in FAILED state
 			function show_failing_pods() {
-				failed_pods=$(kubectl get pod -l "release=$RELEASE_NAME,cronjob!=true" -n "$NAMESPACE" --no-headers | grep -Ev '([0-9]+)/\1' | grep -Eo '^[^ ]+')
+				echo ""
+				failed_pods=$(kubectl get pod -l "release=$RELEASE_NAME,cronjob!=true" -n "$NAMESPACE" -o custom-columns="POD:metadata.name,STATE:status.containerStatuses[*].ready" --no-headers | grep -E "<none>|false" | grep -Eo '^[^ ]+')
 				if [[ ! -z "$failed_pods" ]] ; then
 					echo "Failing pods:"
-					echo "$failed_pods"
-					echo ""
-					echo "Please check logs for the pods above"
+					while IFS= read -r pod; do
+						echo "---- ${NAMESPACE} / ${pod} ----"
+						echo "* Events"
+						kubectl get events --field-selector involvedObject.name=${pod},type!=Normal --show-kind=true --ignore-not-found=true --namespace ${NAMESPACE}
+						echo ""
+						echo "* Logs"
+						containers=$(kubectl get pods "${pod}" --namespace "${NAMESPACE}" -o json | jq -r 'try .status | .containerStatuses[] | select(.ready == false).name')
+						if [[ ! -z "$containers" ]] ; then
+							for container in ${containers}; do
+								kubectl logs "${pod}" --prefix=true --since="${DEPLOYMENT_TIMEOUT}" --namespace "${NAMESPACE}" -c "${container}" 
+							done
+						else
+							echo "no logs found"
+						fi
+
+						echo "----"
+					done <<< "$failed_pods"
+
+					false
+				else
 					true
 				fi
-				false
 			}
+
+			trap show_failing_pods ERR
 
 			helm upgrade --install "${RELEASE_NAME}" "${CHART_NAME}" \
 				--repo "${CHART_REPOSITORY}" \
@@ -248,16 +267,35 @@ func TestReleaseDeployCmd(t *testing.T) {
 
 			# Detect pods in FAILED state
 			function show_failing_pods() {
-				failed_pods=$(kubectl get pod -l "release=$RELEASE_NAME,cronjob!=true" -n "$NAMESPACE" --no-headers | grep -Ev '([0-9]+)/\1' | grep -Eo '^[^ ]+')
+				echo ""
+				failed_pods=$(kubectl get pod -l "release=$RELEASE_NAME,cronjob!=true" -n "$NAMESPACE" -o custom-columns="POD:metadata.name,STATE:status.containerStatuses[*].ready" --no-headers | grep -E "<none>|false" | grep -Eo '^[^ ]+')
 				if [[ ! -z "$failed_pods" ]] ; then
 					echo "Failing pods:"
-					echo "$failed_pods"
-					echo ""
-					echo "Please check logs for the pods above"
+					while IFS= read -r pod; do
+						echo "---- ${NAMESPACE} / ${pod} ----"
+						echo "* Events"
+						kubectl get events --field-selector involvedObject.name=${pod},type!=Normal --show-kind=true --ignore-not-found=true --namespace ${NAMESPACE}
+						echo ""
+						echo "* Logs"
+						containers=$(kubectl get pods "${pod}" --namespace "${NAMESPACE}" -o json | jq -r 'try .status | .containerStatuses[] | select(.ready == false).name')
+						if [[ ! -z "$containers" ]] ; then
+							for container in ${containers}; do
+								kubectl logs "${pod}" --prefix=true --since="${DEPLOYMENT_TIMEOUT}" --namespace "${NAMESPACE}" -c "${container}" 
+							done
+						else
+							echo "no logs found"
+						fi
+
+						echo "----"
+					done <<< "$failed_pods"
+
+					false
+				else
 					true
 				fi
-				false
 			}
+
+			trap show_failing_pods ERR
 
 			helm upgrade --install "${RELEASE_NAME}" "${CHART_NAME}" \
 				--repo "${CHART_REPOSITORY}" \
@@ -326,7 +364,39 @@ func TestReleaseDeployCmd(t *testing.T) {
 			NAMESPACE='19'
 			SILTA_CONFIG='20'
 			EXTRA_HELM_FLAGS='22'
-			
+
+			# Detect pods in FAILED state
+			function show_failing_pods() {
+				echo ""
+				failed_pods=$(kubectl get pod -l "release=$RELEASE_NAME,cronjob!=true" -n "$NAMESPACE" -o custom-columns="POD:metadata.name,STATE:status.containerStatuses[*].ready" --no-headers | grep -E "<none>|false" | grep -Eo '^[^ ]+')
+				if [[ ! -z "$failed_pods" ]] ; then
+					echo "Failing pods:"
+					while IFS= read -r pod; do
+						echo "---- ${NAMESPACE} / ${pod} ----"
+						echo "* Events"
+						kubectl get events --field-selector involvedObject.name=${pod},type!=Normal --show-kind=true --ignore-not-found=true --namespace ${NAMESPACE}
+						echo ""
+						echo "* Logs"
+						containers=$(kubectl get pods "${pod}" --namespace "${NAMESPACE}" -o json | jq -r 'try .status | .containerStatuses[] | select(.ready == false).name')
+						if [[ ! -z "$containers" ]] ; then
+							for container in ${containers}; do
+								kubectl logs "${pod}" --prefix=true --since="${DEPLOYMENT_TIMEOUT}" --namespace "${NAMESPACE}" -c "${container}" 
+							done
+						else
+							echo "no logs found"
+						fi
+
+						echo "----"
+					done <<< "$failed_pods"
+
+					false
+				else
+					true
+				fi
+			}
+
+			trap show_failing_pods ERR
+
 			helm upgrade --install "${RELEASE_NAME}" "${CHART_NAME}" \
 				--repo "${CHART_REPOSITORY}" \
 				${EXTRA_CHART_VERSION} \
@@ -386,7 +456,39 @@ func TestReleaseDeployCmd(t *testing.T) {
 			NAMESPACE='19'
 			SILTA_CONFIG='20'
 			EXTRA_HELM_FLAGS='22'
-			
+
+			# Detect pods in FAILED state
+			function show_failing_pods() {
+				echo ""
+				failed_pods=$(kubectl get pod -l "release=$RELEASE_NAME,cronjob!=true" -n "$NAMESPACE" -o custom-columns="POD:metadata.name,STATE:status.containerStatuses[*].ready" --no-headers | grep -E "<none>|false" | grep -Eo '^[^ ]+')
+				if [[ ! -z "$failed_pods" ]] ; then
+					echo "Failing pods:"
+					while IFS= read -r pod; do
+						echo "---- ${NAMESPACE} / ${pod} ----"
+						echo "* Events"
+						kubectl get events --field-selector involvedObject.name=${pod},type!=Normal --show-kind=true --ignore-not-found=true --namespace ${NAMESPACE}
+						echo ""
+						echo "* Logs"
+						containers=$(kubectl get pods "${pod}" --namespace "${NAMESPACE}" -o json | jq -r 'try .status | .containerStatuses[] | select(.ready == false).name')
+						if [[ ! -z "$containers" ]] ; then
+							for container in ${containers}; do
+								kubectl logs "${pod}" --prefix=true --since="${DEPLOYMENT_TIMEOUT}" --namespace "${NAMESPACE}" -c "${container}" 
+							done
+						else
+							echo "no logs found"
+						fi
+
+						echo "----"
+					done <<< "$failed_pods"
+
+					false
+				else
+					true
+				fi
+			}
+
+			trap show_failing_pods ERR
+
 			helm upgrade --install "${RELEASE_NAME}" "${CHART_NAME}" \
 				--repo "${CHART_REPOSITORY}" \
 				${EXTRA_CHART_VERSION} \


### PR DESCRIPTION
Updates `show_failing_pods fuction` so it would print logs and events of failed containers. Creates trap that prints logs during other build failures too.

Test builds: https://app.circleci.com/pipelines/github/wunderio/drupal-project-k8s?branch=feature%2Fslt-778-failed-build-log