### PR TITLE
Remove existing pods for post-release when removing job.

### DIFF
--- a/cmd/ciReleaseDelete.go
+++ b/cmd/ciReleaseDelete.go
@@ -67,7 +67,8 @@ var ciReleaseDeleteCmd = &cobra.Command{
 			log.Fatalf("Error removing a release:%s", uninstallErr)
 		}
 
-		deleteErr := clientset.BatchV1().Jobs(namespace).Delete(context.TODO(), releaseName+"-post-release", v1.DeleteOptions{})
+		propagationPolicy := v1.DeletePropagationBackground
+		deleteErr := clientset.BatchV1().Jobs(namespace).Delete(context.TODO(), releaseName+"-post-release", v1.DeleteOptions{PropagationPolicy: &propagationPolicy})
 		if deleteErr != nil {
 			if errs.IsNotFound(deleteErr) {
 				//Resource doesnt exist, lets skip printing a message
@@ -99,7 +100,7 @@ func init() {
 
 	ciReleaseDeleteCmd.Flags().String("release-name", "", "Release name")
 	ciReleaseDeleteCmd.Flags().String("namespace", "", "Project name (namespace, i.e. \"drupal-project\")")
-	ciReleaseDeleteCmd.Flags().Bool("delete-pvcs", false, "Delete PVCs")
+	ciReleaseDeleteCmd.Flags().Bool("delete-pvcs", false, "Delete PVCs (default: false)")
 
 	ciReleaseDeleteCmd.MarkFlagRequired("release-name")
 	ciReleaseDeleteCmd.MarkFlagRequired("namespace")


### PR DESCRIPTION
Removes leftover post-release job pods.
> W1221 09:22:42.122073 1491390 warnings.go:70] child pods are preserved by default when jobs are deleted; set propagationPolicy=Background to remove them or set propagationPolicy=Orphan to suppress this warning
