### PR TITLE
Remove postinstall jobs based on release label instead of hardcoded name

### DIFF
--- a/cmd/ciReleaseDelete.go
+++ b/cmd/ciReleaseDelete.go
@@ -82,7 +82,8 @@ var ciReleaseDeleteCmd = &cobra.Command{
 			}
 			for _, v := range list.Items {
 				log.Printf("Deleting job: %s", v.Name)
-				clientset.BatchV1().Jobs(namespace).Delete(context.TODO(), v.Name, v1.DeleteOptions{})
+				propagationPolicy := v1.DeletePropagationBackground
+				clientset.BatchV1().Jobs(namespace).Delete(context.TODO(), v.Name, v1.DeleteOptions{PropagationPolicy: &propagationPolicy})
 			}
 		}
 


### PR DESCRIPTION
Removes postinstall jobs based on release label instead of hardcoded name