### PR TITLE
Add --wait flag for helm release to enable proper post-release creation

### DIFF
--- a/cmd/ciReleaseDeploy.go
+++ b/cmd/ciReleaseDeploy.go
@@ -341,7 +341,7 @@ var ciReleaseDeployCmd = &cobra.Command{
 
 				# TODO: Rewrite this part
 
-				echo "Waiting for containers to start"
+				echo "Waiting for containers to start and be ready"
 
 				TIME_WAITING=0
 				LOGS_SHOWN=false
@@ -573,7 +573,7 @@ var ciReleaseDeployCmd = &cobra.Command{
 
 				# TODO: Rewrite this part
 				
-				echo "Waiting for containers to start"
+				echo "Waiting for containers to start and be ready"
 
 				TIME_WAITING=0
 				LOGS_SHOWN=false

--- a/cmd/ciReleaseDeploy.go
+++ b/cmd/ciReleaseDeploy.go
@@ -336,6 +336,7 @@ var ciReleaseDeployCmd = &cobra.Command{
 				${EXTRA_DB_USER_PASS} \
 				--values "${SILTA_CONFIG}" \
 				${EXTRA_HELM_FLAGS} \
+				--wait \
 				--timeout "${DEPLOYMENT_TIMEOUT}" &> helm-output.log & pid=$!
 
 				# TODO: Rewrite this part
@@ -567,6 +568,7 @@ var ciReleaseDeployCmd = &cobra.Command{
 				--namespace="${NAMESPACE}" \
 				--values "${SILTA_CONFIG}" \
 				${EXTRA_HELM_FLAGS} \
+				--wait \
 				--timeout "${DEPLOYMENT_TIMEOUT}" &> helm-output.log & pid=$!
 
 				# TODO: Rewrite this part

--- a/tests/release_test.go
+++ b/tests/release_test.go
@@ -222,6 +222,7 @@ func TestReleaseDeployCmd(t *testing.T) {
 				--namespace="${NAMESPACE}" \
 				--values "${SILTA_CONFIG}" \
 				${EXTRA_HELM_FLAGS} \
+				--wait \
 				--timeout "${DEPLOYMENT_TIMEOUT}" &> helm-output.log & pid=$!`
 	CliExecTest(t, command, environment, testString, false)
 
@@ -331,6 +332,7 @@ func TestReleaseDeployCmd(t *testing.T) {
 				--namespace="${NAMESPACE}" \
 				--values "${SILTA_CONFIG}" \
 				${EXTRA_HELM_FLAGS} \
+				--wait \
 				--timeout "${DEPLOYMENT_TIMEOUT}" &> helm-output.log & pid=$!`
 	CliExecTest(t, command, environment, testString, false)
 


### PR DESCRIPTION
This PR reenables `--wait` flag for `helm install / upgrade`. The process itself runs in background anyway and it's pid is watched for timeouts and error printing. 

It's required for proper post-release hook timing, as per [doc](https://helm.sh/docs/topics/charts_hooks/), 
>  if the `--wait` flag is set, the library will wait until all resources are in a ready state and will not run the post-install hook until they are ready.

This should solve the issue where postinstall clears caches, but there's a chance web request to old (non-replaced) replica is hit and it generates module cache from old webroot.

This was tested with both succeeding and failing deployments for drupal and frontend chart, no regressions spotted.

<img width="1139" alt="helm-wait-flag" src="https://github.com/wunderio/silta-cli/assets/922901/a055edf2-babe-42e8-a61a-3f406c48cdf3">
