### PR TITLE
Use provided deployment timeout to timeout

### DIFF
--- a/cmd/ciReleaseDeploy.go
+++ b/cmd/ciReleaseDeploy.go
@@ -100,7 +100,7 @@ var ciReleaseDeployCmd = &cobra.Command{
 		deploymentTimeoutSeconds := 900
 		deploymentTimeoutDuration, err := time.ParseDuration(deploymentTimeout)
 		if err != nil {
-		    deploymentTimeoutSeconds = 900
+		    log.Println("Invalid deployment timeout duration, using default 15m.")
 		} else {
 		    deploymentTimeoutSeconds = int(deploymentTimeoutDuration.Seconds())
 		}

--- a/cmd/ciReleaseDeploy.go
+++ b/cmd/ciReleaseDeploy.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/wunderio/silta-cli/internal/common"
@@ -95,6 +96,15 @@ var ciReleaseDeployCmd = &cobra.Command{
 		if len(deploymentTimeout) == 0 {
 			deploymentTimeout = "15m"
 		}
+		// Convert deploymentTimeout to integer of seconds
+		deploymentTimeoutSeconds := 900
+		deploymentTimeoutDuration, err := time.ParseDuration(deploymentTimeout)
+		if err != nil {
+		    deploymentTimeoutSeconds = 900
+		} else {
+		    deploymentTimeoutSeconds = int(deploymentTimeoutDuration.Seconds())
+		}
+
 		if len(chartRepository) == 0 {
 			chartRepository = "https://storage.googleapis.com/charts.wdr.io"
 		}
@@ -285,6 +295,7 @@ var ciReleaseDeployCmd = &cobra.Command{
 			SILTA_CONFIG='%s'
 			EXTRA_HELM_FLAGS='%s'
 			DEPLOYMENT_TIMEOUT='%s'
+			DEPLOYMENT_TIMEOUT_SECONDS='%d'
 
 			# Detect pods in FAILED state
 			function show_failing_pods() {
@@ -364,7 +375,7 @@ var ciReleaseDeployCmd = &cobra.Command{
 						break
 					fi
 
-					if [ $TIME_WAITING -gt 300 ]; then
+					if [ $TIME_WAITING -gt ${DEPLOYMENT_TIMEOUT_SECONDS} ]; then
 						echo "Timeout waiting for resources."
 						show_failing_pods
 						exit 1
@@ -390,7 +401,7 @@ var ciReleaseDeployCmd = &cobra.Command{
 				extraNoAuthIPs, vpcNativeOverride, extraClusterType,
 				dbRootPassOverride, dbUserPassOverride,
 				siltaConfig, helmFlags,
-				deploymentTimeout)
+				deploymentTimeout, deploymentTimeoutSeconds)
 			pipedExec(command, debug)
 
 		} else if chartName == "drupal" || strings.HasSuffix(chartName, "/drupal") {
@@ -513,6 +524,7 @@ var ciReleaseDeployCmd = &cobra.Command{
 			SILTA_CONFIG='%s'
 			EXTRA_HELM_FLAGS='%s'
 			DEPLOYMENT_TIMEOUT='%s'
+			DEPLOYMENT_TIMEOUT_SECONDS='%d'
 
 			# Detect pods in FAILED state
 			function show_failing_pods() {
@@ -596,7 +608,7 @@ var ciReleaseDeployCmd = &cobra.Command{
 						break
 					fi
 
-					if [ $TIME_WAITING -gt 300 ]; then
+					if [ $TIME_WAITING -gt ${DEPLOYMENT_TIMEOUT_SECONDS} ]; then
 						echo "Timeout waiting for resources."
 						show_failing_pods
 						exit 1
@@ -621,7 +633,7 @@ var ciReleaseDeployCmd = &cobra.Command{
 				repositoryUrl, gitAuthUsername, gitAuthPassword,
 				clusterDomain, extraNoAuthIPs, vpcNativeOverride, extraClusterType,
 				dbRootPassOverride, dbUserPassOverride, referenceDataOverride, namespace,
-				siltaConfig, helmFlags, deploymentTimeout)
+				siltaConfig, helmFlags, deploymentTimeout, deploymentTimeoutSeconds)
 			pipedExec(command, debug)
 
 		} else {

--- a/tests/release_test.go
+++ b/tests/release_test.go
@@ -167,6 +167,7 @@ func TestReleaseDeployCmd(t *testing.T) {
 			SILTA_CONFIG=''
 			EXTRA_HELM_FLAGS=''
 			DEPLOYMENT_TIMEOUT='15m'
+			DEPLOYMENT_TIMEOUT_SECONDS='900'
 
 			# Detect pods in FAILED state
 			function show_failing_pods() {
@@ -277,6 +278,7 @@ func TestReleaseDeployCmd(t *testing.T) {
 			SILTA_CONFIG='20'
 			EXTRA_HELM_FLAGS='21'
 			DEPLOYMENT_TIMEOUT='22'
+			DEPLOYMENT_TIMEOUT_SECONDS='900'
 
 			# Detect pods in FAILED state
 			function show_failing_pods() {


### PR DESCRIPTION
## Sync deployment and wait timeout

**Reasoning:** Currently it does not matter if deployment_timeout is set to 15m in silta orb. Deployment exits with "Timeout waiting for resources" after 300 seconds ignoring deployment_timeout.

**Features:**
- Converts already used deploymentTimout to integer of seconds
- Uses deploymentTimoutSeconds as comparison for $TIME_WAITING
