### PR TITLE
Remove "ERROR:" prefix from docker image builds

### DIFF
--- a/cmd/ciImageBuild.go
+++ b/cmd/ciImageBuild.go
@@ -204,7 +204,7 @@ var ciImageBuildCmd = &cobra.Command{
 			extraImageTagString = fmt.Sprintf("--tag '%s:%s'", imageUrl, extraImageTag)
 		}
 		command := fmt.Sprintf("docker build --tag '%s:%s' %s -f '%s' %s", imageUrl, imageTag, extraImageTagString, dockerfile, buildPath)
-		pipedExec(command, debug)
+		pipedExec(command, "", "", debug)
 
 		// Create AWS/ECR repository (ECR requires a dedicated repository per project)
 		if strings.HasSuffix(imageRepoHost, ".amazonaws.com") {
@@ -223,12 +223,12 @@ var ciImageBuildCmd = &cobra.Command{
 
 		// Image push
 		command = fmt.Sprintf("docker push '%s:%s'", imageUrl, imageTag)
-		pipedExec(command, debug)
+		pipedExec(command, "", "ERROR: ", debug)
 
 		// Push extra tags
 		if len(branchName) > 0 {
 			command = fmt.Sprintf("docker push '%s:%s'", imageUrl, extraImageTag)
-			pipedExec(command, debug)
+			pipedExec(command, "", "ERROR: ", debug)
 		}
 	},
 }

--- a/cmd/ciReleaseCleanfailed.go
+++ b/cmd/ciReleaseCleanfailed.go
@@ -46,7 +46,7 @@ var ciReleaseCleanfailedCmd = &cobra.Command{
 					kubectl delete secret -n "${NAMESPACE}" "${secret_to_delete}"
 				fi
 				`, namespace, releaseName)
-		pipedExec(command, debug)
+		pipedExec(command, "", "ERROR: ", debug)
 	},
 }
 

--- a/cmd/ciReleaseDeploy.go
+++ b/cmd/ciReleaseDeploy.go
@@ -160,7 +160,7 @@ var ciReleaseDeployCmd = &cobra.Command{
 				fi
 
 			`, namespace)
-		pipedExec(command, debug)
+		pipedExec(command, "", "ERROR: ", debug)
 
 		if !debug {
 			// Add helm repositories
@@ -257,7 +257,7 @@ var ciReleaseDeployCmd = &cobra.Command{
 				siltaEnvironmentName, branchname, nginxImageUrl,
 				clusterDomain, extraNoAuthIPs, vpcNativeOverride, extraClusterType,
 				namespace, siltaConfig, helmFlags, deploymentTimeout)
-			pipedExec(command, debug)
+			pipedExec(command, "", "ERROR: ", debug)
 
 		} else if chartName == "frontend" || strings.HasSuffix(chartName, "/frontend") {
 
@@ -398,7 +398,7 @@ var ciReleaseDeployCmd = &cobra.Command{
 				dbRootPassOverride, dbUserPassOverride,
 				siltaConfig, helmFlags,
 				deploymentTimeout, deploymentTimeoutSeconds)
-			pipedExec(command, debug)
+			pipedExec(command, "", "ERROR: ", debug)
 
 		} else if chartName == "drupal" || strings.HasSuffix(chartName, "/drupal") {
 
@@ -441,7 +441,7 @@ var ciReleaseDeployCmd = &cobra.Command{
 						fi
 					fi
 				`, namespace, releaseName)
-			pipedExec(command, debug)
+			pipedExec(command, "", "ERROR: ", debug)
 
 			// Clean up failed Helm releases
 			// TODO: Rewrite
@@ -477,7 +477,7 @@ var ciReleaseDeployCmd = &cobra.Command{
 						kubectl delete secret -n "$NAMESPACE" "$secret_to_delete"
 					fi
 				`, namespace, releaseName)
-			pipedExec(command, debug)
+			pipedExec(command, "", "ERROR: ", debug)
 
 			// Chart value overrides
 
@@ -630,7 +630,7 @@ var ciReleaseDeployCmd = &cobra.Command{
 				clusterDomain, extraNoAuthIPs, vpcNativeOverride, extraClusterType,
 				dbRootPassOverride, dbUserPassOverride, referenceDataOverride, namespace,
 				siltaConfig, helmFlags, deploymentTimeout, deploymentTimeoutSeconds)
-			pipedExec(command, debug)
+			pipedExec(command, "", "ERROR: ", debug)
 
 		} else {
 			fmt.Printf("Chart name %s does not match preselected names (drupal, frontend, simple), helm release step was skipped\n", chartName)

--- a/cmd/ciReleaseInfo.go
+++ b/cmd/ciReleaseInfo.go
@@ -72,7 +72,7 @@ but namespace is normalized lowercase version of it.
 					curl -H "Authorization: token ${GITHUB_TOKEN}" -H "Content-Type: application/json" -X POST -d '{"body": "<details><summary>Release notes for '${RELEASE_NAME}'</summary>'"${FORMATTED_NOTES//$'\n'/'\n'}"'</details>"}' ${GITHUB_API_URL}
 				fi
 				`, namespace, releaseName, githubToken, circlePrNumber, circlePullRequest, circleProjectUsername, circleProjectReponame)
-		pipedExec(command, debug)
+		pipedExec(command, "", "ERROR: ", debug)
 
 		command = fmt.Sprintf(`
 				NAMESPACE='%s'

--- a/cmd/ciReleaseValidate.go
+++ b/cmd/ciReleaseValidate.go
@@ -109,7 +109,7 @@ var ciReleaseValidateCmd = &cobra.Command{
 			fi
 			`, namespace, releaseName)
 
-		pipedExec(command, debug)
+		pipedExec(command, "", "ERROR: ", debug)
 
 		if chartName == "drupal" || strings.HasSuffix(chartName, "/drupal") {
 

--- a/cmd/ciToolsCheck.go
+++ b/cmd/ciToolsCheck.go
@@ -26,7 +26,7 @@ var ciToolsCheckCmd = &cobra.Command{
 				log.Println(bin + " is installed")
 				if cmd != "" {
 					command := fmt.Sprintf("%s %s", bin, cmd)
-					pipedExec(command, debug)
+					pipedExec(command, "", "ERROR: ", debug)
 				}
 			}
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,7 +48,7 @@ func bufferedExec(command string, debug bool) {
 	}
 }
 
-func pipedExec(command string, debug bool) {
+func pipedExec(command string, stdOutPrefix string, stdErrPrefix string, debug bool) {
 	if debug == true {
 		fmt.Printf("Command (not executed): %s\n", command)
 	} else {
@@ -71,12 +71,12 @@ func pipedExec(command string, debug bool) {
 		errScanner := bufio.NewScanner(cmdErrReader)
 		go func() {
 			for errScanner.Scan() {
-				fmt.Printf("ERROR: %s\n", errScanner.Text())
+				fmt.Printf("%s%s\n", stdErrPrefix, errScanner.Text())
 			}
 		}()
 		go func() {
 			for outScanner.Scan() {
-				fmt.Printf("%s\n", outScanner.Text())
+				fmt.Printf("%s%s\n", stdOutPrefix, outScanner.Text())
 			}
 		}()
 		err = cmd.Start()


### PR DESCRIPTION
docker image build in cci returns build logs into stderr. this pr tackles docker build wrapper case, removes "ERROR: " prefix.