### PR TITLE
Quote docker login parameters

### DIFF
--- a/cmd/ciImageLogin.go
+++ b/cmd/ciImageLogin.go
@@ -117,14 +117,14 @@ Available flags and environment variables:
 					protocol = "http://"
 				}
 				// User && pass login
-				command = fmt.Sprintf("echo %q | docker login --username %q --password-stdin %s%s", imageRepoPass, imageRepoUser, protocol, imageRepoHost)
+				command = fmt.Sprintf("echo '%s' | docker login --username '%s' --password-stdin '%s%s'", imageRepoPass, imageRepoUser, protocol, imageRepoHost)
 
 			} else if gcpKeyJson != "" {
 				// GCR login
 				if !strings.Contains(imageRepoHost, "://") {
 					imageRepoHost = "https://" + imageRepoHost
 				}
-				command = fmt.Sprintf("echo %q | docker login --username %q --password-stdin %s", gcpKeyJson, "_json_key", imageRepoHost)
+				command = fmt.Sprintf("echo '%s' | docker login --username '%s' --password-stdin '%s'", gcpKeyJson, "_json_key", imageRepoHost)
 
 			} else if awsSecretAccessKey != "" {
 				//Get AWS Account ID
@@ -137,11 +137,11 @@ Available flags and environment variables:
 				// ECR login
 				command = fmt.Sprintf("aws ecr get-login-password --region %s | docker login --username AWS --password-stdin %s.dkr.ecr.%s.amazonaws.com", awsRegion, awsAccountId, awsRegion)
 				// TODO: use aws cli v2
-				// command = fmt.Sprintf("echo %q | docker login --username AWS --password-stdin %s", awsSecretAccessKey, imageRepoHost)
+				// command = fmt.Sprintf("echo '%s' | docker login --username AWS --password-stdin %s", awsSecretAccessKey, imageRepoHost)
 
 			} else if aksSPPass != "" {
 				// ACR Login
-				command = fmt.Sprintf("echo %q | docker login --username %q --password-stdin %s", aksSPPass, aksSPAppID, imageRepoHost)
+				command = fmt.Sprintf("echo '%s' | docker login --username '%s' --password-stdin '%s'", aksSPPass, aksSPAppID, imageRepoHost)
 			}
 
 			if command != "" {

--- a/tests/image_test.go
+++ b/tests/image_test.go
@@ -17,7 +17,7 @@ func TestImageLoginCmd(t *testing.T) {
 		"IMAGE_REPO_HOST=foo.bar",
 		"GCLOUD_KEY_JSON=baz",
 	}
-	testString := `echo "baz" | docker login --username "_json_key" --password-stdin https://foo.bar`
+	testString := `echo 'baz' | docker login --username '_json_key' --password-stdin 'https://foo.bar`
 	CliExecTest(t, command, environment, testString, false)
 
 	// Test all env
@@ -43,7 +43,7 @@ AWS_REGION: 555
 AKS_TENANT_ID: 666
 AKS_SP_APP_ID: 777
 AKS_SP_PASSWORD: 888
-Command (not executed): echo "222" | docker login --username "111" --password-stdin https://foo.bar`
+Command (not executed): echo '222' | docker login --username '111' --password-stdin 'https://foo.bar'`
 
 	CliExecTest(t, command, environment, testString, false)
 
@@ -56,7 +56,7 @@ Command (not executed): echo "222" | docker login --username "111" --password-st
 	// Test args
 	command = "ci image login --image-repo-host foo.bar --gcp-key-json baz --debug"
 	environment = []string{}
-	testString = `echo "baz" | docker login --username "_json_key" --password-stdin https://foo.bar`
+	testString = `echo 'baz' | docker login --username '_json_key' --password-stdin 'https://foo.bar'`
 	CliExecTest(t, command, environment, testString, false)
 
 	// Test all args
@@ -83,7 +83,7 @@ AWS_REGION: 555
 AKS_TENANT_ID: 666
 AKS_SP_APP_ID: 777
 AKS_SP_PASSWORD: 888
-Command (not executed): echo "222" | docker login --username "111" --password-stdin https://foo.bar`
+Command (not executed): echo '222' | docker login --username '111' --password-stdin 'https://foo.bar'`
 	CliExecTest(t, command, environment, testString, false)
 
 	// Test args+env merge
@@ -92,7 +92,7 @@ Command (not executed): echo "222" | docker login --username "111" --password-st
 		"IMAGE_REPO_HOST=bar.bar",
 		"GCLOUD_KEY_JSON=baz",
 	}
-	testString = `echo "baz" | docker login --username "_json_key" --password-stdin https://foo.bar`
+	testString = `echo 'baz' | docker login --username '_json_key' --password-stdin 'https://foo.bar'`
 	CliExecTest(t, command, environment, testString, false)
 
 	// Change dir back to previous


### PR DESCRIPTION
Adds single quote instead of double quote to avoid parsing parameters (fixes issue where username contains dollar sign) 