### PR TITLE
Use KUBECONFIG environment variable first

### DIFF
--- a/cmd/ciReleaseDeploy.go
+++ b/cmd/ciReleaseDeploy.go
@@ -150,12 +150,22 @@ var ciReleaseDeployCmd = &cobra.Command{
 		}
 
 		if !debug {
-			// Connect to the cluster
-			homeDir, err := os.UserHomeDir()
-			if err != nil {
-				log.Fatalf("cannot read user home dir")
+
+			// Try reading KUBECONFIG from environment variable first
+			kubeConfigPath := os.Getenv("KUBECONFIG")
+			if kubeConfigPath == "" {
+				// If not set, use the default kube config path
+				homeDir, err := os.UserHomeDir()
+				if err != nil {
+					log.Fatalf("cannot read user home dir")
+				}
+				kubeConfigPath = homeDir + "/.kube/config"
 			}
-			kubeConfigPath := homeDir + "/.kube/config"
+
+			// Read kubeConfig from file
+			if _, err := os.Stat(kubeConfigPath); os.IsNotExist(err) {
+				log.Fatalf("kubeConfig file does not exist at path: %s", kubeConfigPath)
+			}
 
 			//k8s go client init logic
 			config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)

--- a/cmd/ciReleaseDiff.go
+++ b/cmd/ciReleaseDiff.go
@@ -280,12 +280,19 @@ var ciReleaseDiffCmd = &cobra.Command{
 			referenceDataOverride := ""
 			if !debug {
 
-				homeDir, err := os.UserHomeDir()
-				if err != nil {
-					log.Fatalf("cannot read user home dir")
+				// Try reading KUBECONFIG from environment variable first
+				kubeConfigPath := os.Getenv("KUBECONFIG")
+				if kubeConfigPath == "" {
+					homeDir, err := os.UserHomeDir()
+					if err != nil {
+						log.Fatalf("cannot read user home dir")
+					}
+					kubeConfigPath = homeDir + "/.kube/config"
 				}
-				kubeConfigPath := homeDir + "/.kube/config"
-
+				// Read kubeConfig from file
+				if _, err := os.Stat(kubeConfigPath); os.IsNotExist(err) {
+					log.Fatalf("kubeConfig file does not exist at path: %s", kubeConfigPath)
+				}
 				//k8s go client init logic
 				config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
 				if err != nil {

--- a/cmd/ciReleaseList.go
+++ b/cmd/ciReleaseList.go
@@ -19,12 +19,17 @@ var ciReleaseListCmd = &cobra.Command{
 
 		namespace, _ := cmd.Flags().GetString("namespace")
 
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			fmt.Println("cannot read user home dir")
-			os.Exit(1)
+		// Try reading KUBECONFIG from environment variable first
+		kubeConfigPath := os.Getenv("KUBECONFIG")
+		if kubeConfigPath == "" {
+			// If not set, use the default kube config path
+			homeDir, err := os.UserHomeDir()
+			if err != nil {
+				fmt.Println("cannot read user home dir")
+				os.Exit(1)
+			}
+			kubeConfigPath = homeDir + "/.kube/config"
 		}
-		kubeConfigPath := homeDir + "/.kube/config"
 
 		kubeConfig, err := os.ReadFile(kubeConfigPath)
 		if err != nil {

--- a/cmd/ciReleaseValidate.go
+++ b/cmd/ciReleaseValidate.go
@@ -93,14 +93,14 @@ var ciReleaseValidateCmd = &cobra.Command{
 			pending_release=$(helm list -n "$NAMESPACE" --pending --filter="(\s|^)($RELEASE_NAME)(\s|$)"| tail -1 | cut -f1)
 
 			if [[ "$pending_release" == "$RELEASE_NAME" ]]; then
-				upgrade_secret_to_delete=$(kubectl get secret -l owner=helm,status=pending-upgrade,name="$RELEASE_NAME" -n "$NAMESPACE" | awk '{print $1}' | grep -v NAME)
-				install_secret_to_delete=$(kubectl get secret -l owner=helm,status=pending-install,name="$RELEASE_NAME" -n "$NAMESPACE" | awk '{print $1}' | grep -v NAME)
+				upgrade_secret_to_delete=$(kubectl get secret -l owner=helm,status=pending-upgrade,name="$RELEASE_NAME" -n "$NAMESPACE" --no-headers | awk '{print $1}')
+				install_secret_to_delete=$(kubectl get secret -l owner=helm,status=pending-install,name="$RELEASE_NAME" -n "$NAMESPACE" --no-headers | awk '{print $1}')
 				
 				if [[ ! -z "$upgrade_secret_to_delete" ]] ; then
-					kubectl delete secret -n "$NAMESPACE" "$upgrade_secret_to_delete"
+					kubectl delete secret -n "$NAMESPACE" "$upgrade_secret_to_delete" || true
 				fi
 				if [[ ! -z "$install_secret_to_delete" ]] ; then
-					kubectl delete secret -n "$NAMESPACE" "$install_secret_to_delete"
+					kubectl delete secret -n "$NAMESPACE" "$install_secret_to_delete" || true
 				fi
 			fi
 			`, namespace, releaseName)

--- a/cmd/ciReleaseWakeup.go
+++ b/cmd/ciReleaseWakeup.go
@@ -24,15 +24,19 @@ var ciReleaseWakeupCmd = &cobra.Command{
 		releaseName, _ := cmd.Flags().GetString("release-name")
 		namespace, _ := cmd.Flags().GetString("namespace")
 
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			log.Fatalf("cannot read user home dir")
+		// Try reading KUBECONFIG from environment variable first
+		kubeConfigPath := os.Getenv("KUBECONFIG")
+		if kubeConfigPath == "" {
+			homeDir, err := os.UserHomeDir()
+			if err != nil {
+				log.Fatalf("cannot read user home dir")
+			}
+			kubeConfigPath = homeDir + "/.kube/config"
 		}
-		kubeConfigPath := homeDir + "/.kube/config"
 
 		kubeConfig, err := os.ReadFile(kubeConfigPath)
 		if err != nil {
-			log.Fatalf("cannot read kubeConfig from path")
+			log.Fatalf("cannot read kubeConfig from path: %s", kubeConfigPath)
 		}
 
 		// k8s go client init logic

--- a/cmd/ciScriptsEsInitRemove.go
+++ b/cmd/ciScriptsEsInitRemove.go
@@ -30,17 +30,22 @@ var ciScriptsEsinitRemoveCmd = &cobra.Command{
 			fmt.Printf("Namespace: %s\n", namespace)
 		}
 
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			log.Fatalf("cannot read user home dir")
+		// Try reading KUBECONFIG from environment variable first
+		kubeConfigPath := os.Getenv("KUBECONFIG")
+		if kubeConfigPath == "" {
+			homeDir, err := os.UserHomeDir()
+			if err != nil {
+				log.Fatalf("cannot read user home dir")
+			}
+			kubeConfigPath = homeDir + "/.kube/config"
 		}
-		kubeConfigPath := homeDir + "/.kube/config"
 
 		//k8s go client init logic
 		config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
 		if err != nil {
-			log.Fatalf("cannot read kubeConfig from path: %s", err)
+			log.Fatalf("cannot read kubeConfig from path: %s", kubeConfigPath)
 		}
+
 		clientset, err := kubernetes.NewForConfig(config)
 		if err != nil {
 			log.Fatalf("cannot initialize k8s client: %s", err)


### PR DESCRIPTION
This mirrors behavior of other cli tools where `KUBECONFIG` environment variable takes precedence for kubeconfig location.