### PR TITLE
Upload release binaries to gcs

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: azure/setup-helm@v3
         with:
-          version: 'v3.6.3'
+          version: 'v3.18.4'
         name: Install Helm
       - name: Add wunderio Helm repo
         run: helm repo add wunderio https://storage.googleapis.com/charts.wdr.io
@@ -40,16 +40,37 @@ jobs:
         goarch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v3
+      - name: Auth to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
       - name: Set output
         id: vars
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-      - uses: wangyoucao577/go-release-action@v1.24
+      - name: Build binary
+        run: |
+          mkdir -p dist
+          RELEASE_TAG="master"
+          BIN_NAME="silta-${{ matrix.goos }}-${{ matrix.goarch }}"
+          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} \
+            go build -ldflags "-X github.com/wunderio/silta-cli/internal/common.Version=${{ steps.vars.outputs.sha_short }} -s -w" \
+            -o dist/$BIN_NAME
+          tar -czf dist/silta-${RELEASE_TAG}-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz \
+            -C dist $BIN_NAME --transform="s|$BIN_NAME|silta|"
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          goos: ${{ matrix.goos }}
-          goarch: ${{ matrix.goarch }}
-          release_tag: master
-          overwrite: true
-          goversion: "https://go.dev/dl/go1.24.4.linux-amd64.tar.gz"
-          binary_name: "silta"
-          ldflags: "-X github.com/wunderio/silta-cli/internal/common.Version=${{ steps.vars.outputs.sha_short }} -s -w"
+          tag_name: "master"
+          files: dist/silta-master-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload to GCS
+        run: |
+          RELEASE_TAG="master"
+          FILE_NAME="silta-${RELEASE_TAG}-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz"
+          gsutil cp "dist/$FILE_NAME" \
+            "gs://${{ secrets.GCP_BUCKET_NAME }}/releases/${RELEASE_TAG}/$FILE_NAME"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: azure/setup-helm@v3
         with:
-          version: 'v3.6.3'
+          version: 'v3.18.4'
         name: Install Helm
       - name: Add wunderio Helm repo
         run: helm repo add wunderio https://storage.googleapis.com/charts.wdr.io
@@ -39,17 +39,47 @@ jobs:
         goarch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v4
+      - name: Auth to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
       - name: Set output
         id: vars
         run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
-      - uses: wangyoucao577/go-release-action@v1.24
+      - name: Build binary
+        run: |
+          mkdir -p dist
+          RELEASE_TAG="${{ steps.vars.outputs.tag }}"
+          BIN_NAME="silta-${{ matrix.goos }}-${{ matrix.goarch }}"
+          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} \
+            go build -ldflags "-X github.com/wunderio/silta-cli/internal/common.Version=${RELEASE_TAG} -s -w" \
+            -o dist/$BIN_NAME
+          tar -czf dist/silta-${RELEASE_TAG}-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz \
+            -C dist $BIN_NAME --transform="s|$BIN_NAME|silta|"
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          goos: ${{ matrix.goos }}
-          goarch: ${{ matrix.goarch }}
-          goversion: "https://go.dev/dl/go1.24.4.linux-amd64.tar.gz"
-          binary_name: "silta"
-          ldflags: "-X github.com/wunderio/silta-cli/internal/common.Version=${{ steps.vars.outputs.tag }} -s -w"
+          tag_name: "${{ steps.vars.outputs.tag }}"
+          files: dist/silta-${{ steps.vars.outputs.tag }}-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload to GCS
+        run: |
+          RELEASE_TAG="${{ steps.vars.outputs.tag }}"
+          FILE_NAME="silta-${RELEASE_TAG}-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz"
+          gsutil cp "dist/$FILE_NAME" \
+            "gs://${{ secrets.GCP_BUCKET_NAME }}/releases/${RELEASE_TAG}/$FILE_NAME"
+          # Upload as latest version
+          RELEASE_TAG="latest"
+          FILE_NAME="silta-${RELEASE_TAG}-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz"
+          gsutil cp "dist/$FILE_NAME" \
+            "gs://${{ secrets.GCP_BUCKET_NAME }}/releases/${RELEASE_TAG}/$FILE_NAME"
+          
+
   circleci-k8s-test-build:
     name: Test released CLI
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: azure/setup-helm@v3
         with:
-          version: 'v3.6.3'
+          version: 'v3.18.4'
         name: Install Helm
       - name: Add wunderio Helm repo
         run: helm repo add wunderio https://storage.googleapis.com/charts.wdr.io
@@ -40,16 +40,37 @@ jobs:
         goarch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v3
+      - name: Auth to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
       - name: Set output
         id: vars
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-      - uses: wangyoucao577/go-release-action@v1.24
+      - name: Build binary
+        run: |
+          mkdir -p dist
+          RELEASE_TAG="test"
+          BIN_NAME="silta-${{ matrix.goos }}-${{ matrix.goarch }}"
+          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} \
+            go build -ldflags "-X github.com/wunderio/silta-cli/internal/common.Version=${{ steps.vars.outputs.sha_short }} -s -w" \
+            -o dist/$BIN_NAME
+          tar -czf dist/silta-${RELEASE_TAG}-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz \
+            -C dist $BIN_NAME --transform="s|$BIN_NAME|silta|"
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          goos: ${{ matrix.goos }}
-          goarch: ${{ matrix.goarch }}
-          release_tag: test
-          overwrite: true
-          goversion: "https://go.dev/dl/go1.24.4.linux-amd64.tar.gz"
-          binary_name: "silta"
-          ldflags: "-X github.com/wunderio/silta-cli/internal/common.Version=${{ steps.vars.outputs.sha_short }} -s -w"
+          tag_name: "test"
+          files: dist/silta-test-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload to GCS
+        run: |
+          RELEASE_TAG="test"
+          FILE_NAME="silta-${RELEASE_TAG}-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz"
+          gsutil cp "dist/$FILE_NAME" \
+            "gs://${{ secrets.GCP_BUCKET_NAME }}/releases/${RELEASE_TAG}/$FILE_NAME"


### PR DESCRIPTION
- Helm version set to the same as ci/cd images
- Release action changed to retain files and enable asset uploads to gcs
- Tagged release assets always duplicated as latest

Github asset download (no changes)
```
# Latest tagged release
latest_release_url=$(curl -sL https://api.github.com/repos/wunderio/silta-cli/releases/latest | grep -o -E "https://(.*)silta-(.*)-linux-amd64.tar.gz" | head -1)
curl -sL $latest_release_url | tar xz -C ~/.local/bin

# Selected release (i.e. 0.1.0)
curl -sL https://github.com/wunderio/silta-cli/releases/download/0.1.0/silta-0.1.0-linux-amd64.tar.gz | tar xz -C ~/.local/bin

# Latest build from master branch
curl -sL https://github.com/wunderio/silta-cli/releases/download/master/silta-master-linux-amd64.tar.gz | tar xz -C ~/.local/bin
```

GCS asset download
```
# Latest tagged release
curl -sL https://silta-cli.wdr.io/releases/latest/silta-latest-linux-amd64.tar.gz | tar xz -C ~/.local/bin

# Selected release (i.e. 0.1.0)
curl -sL https://silta-cli.wdr.io/releases/0.1.0/silta-0.1.0-linux-amd64.tar.gz | tar xz -C ~/.local/bin

# Latest build from master branch
curl -sL https://silta-cli.wdr.io/releases/master/silta-master-linux-amd64.tar.gz | tar xz -C ~/.local/bin
```